### PR TITLE
Override response headers to allow websites that block iframes to be linted

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,7 @@
 	"action": {
 		"default_title": "__MSG_action_default_title__"
 	},
-	"permissions": ["activeTab", "scripting"],
+	"permissions": ["activeTab", "scripting", "declarativeNetRequest", "browsingData"],
 	"background": {
 		"service_worker": "service-worker.js"
 	}

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,12 +1,57 @@
 import { initCollector } from './scripts/collector'
 
+async function configureNetRequest(tabId, domain) {
+  const domains = [domain];
+  const headers = [
+    "X-Frame-Options",
+    "Frame-Options",
+    "Content-Security-Policy",
+  ];
+
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: [1],
+    addRules: [
+      {
+        id: 1,
+        action: {
+          type: "modifyHeaders",
+          responseHeaders: headers.map((h) => ({
+            header: h,
+            operation: "remove",
+          })),
+        },
+        condition: {
+          requestDomains: domains,
+          resourceTypes: ["sub_frame"],
+          tabIds: [tabId],
+        },
+      },
+    ],
+  });
+
+  await chrome.browsingData.remove(
+    {
+      origins: domains.map((d) => `https://${d}`),
+    },
+    {
+      cacheStorage: true,
+      serviceWorkers: true,
+    }
+  );
+}
+
 /**
  * Run the collector script when the extension is clicked
  * @param {chrome.tabs.Tab} tab The current tab the user is on
  */
-chrome.action.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
+  const domain = new URL(tab.url).hostname;
+
+  // Remove response headers that block iframes
+  await configureNetRequest(tab.id, domain);
+
   // Inject the collector script into the current tab
-  chrome.scripting.executeScript({
+  await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     func: initCollector,
   }).then(() => console.log('Script injected'))

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -54,5 +54,7 @@ chrome.action.onClicked.addListener(async (tab) => {
   await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     func: initCollector,
-  }).then(() => console.log('Script injected'))
+  })
+
+  console.log('Script injected')
 })


### PR DESCRIPTION
This needs to be tested - theoretically works but I don't know how to pack the extension to get all the required properties in the manifest and scripts loaded correctly in your codebase. 

Here's a site with headers that block iframes to test with: https://performance.shopify.com/

One thing - the back button seems to go back too far. 